### PR TITLE
docs(infrastructure): add Portainer usage and setup documentation

### DIFF
--- a/Infrastructure/portainer/README.md
+++ b/Infrastructure/portainer/README.md
@@ -1,0 +1,39 @@
+# PORTAINER
+
+Documentação do Portainer
+
+[https://docs.portainer.io/](https://docs.portainer.io/)
+
+Docker image
+
+[portainer/portainer-ce](https://hub.docker.com/r/portainer/portainer-ce)
+
+## Usage
+
+Ajustar o endpoint do traefik no arquivo docker-compose.yml
+
+```yaml
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.portainer.rule=Host(`portainer.yourdomain.com.br`)"
+      - "traefik.http.routers.portainer.entrypoints=websecure"
+      - "traefik.http.services.portainer.loadbalancer.server.port=9000"
+```
+
+## Comands
+
+```bash
+docker compose build
+```
+
+```bash
+docker compose up -d
+```
+
+```bash
+docker compose down
+```
+
+```bash
+docker compose rm
+```

--- a/Infrastructure/portainer/README.md
+++ b/Infrastructure/portainer/README.md
@@ -1,0 +1,40 @@
+# PORTAINER
+
+Documentação do Portainer
+
+[https://docs.portainer.io/](https://docs.portainer.io/)
+
+Docker image
+
+[portainer/portainer-ce](https://hub.docker.com/r/portainer/portainer-ce)
+
+## Usage
+
+Ajustar o endpoint do traefik no arquivo docker-compose.yml
+
+```yaml
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.CONTAINER_NAME.rule=Host(`HOSTNAME`)"
+      - "traefik.http.routers.CONTAINER_NAME.entrypoints=websecure"
+      - "traefik.http.services.CONTAINER_NAME.loadbalancer.server.port=8108"
+      - "traefik.docker.network=production"
+```
+
+## Comands
+
+```bash
+docker compose build
+```
+
+```bash
+docker compose up -d
+```
+
+```bash
+docker compose down
+```
+
+```bash
+docker compose rm
+```

--- a/Infrastructure/portainer/docker-compose.yml
+++ b/Infrastructure/portainer/docker-compose.yml
@@ -5,21 +5,21 @@ networks:
 
 services:
   portainer:
-      image: portainer/portainer-ce:latest
-      container_name: portainer
-      restart: unless-stopped
-      ports:
-        - "9443:9000"
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock:ro
-        - portainer_data:/data
-      labels:
-        - "traefik.enable=true"
-        - "traefik.http.routers.portainer.rule=Host(`portainer.yourdomain.com.br`)"
-        - "traefik.http.routers.portainer.entrypoints=websecure"
-        - "traefik.http.services.portainer.loadbalancer.server.port=9000"
-      networks:
-        - production
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    restart: unless-stopped
+    ports:
+      - "9443:9000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - portainer_data:/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.portainer.rule=Host(`portainer.yourdomain.com.br`)"
+      - "traefik.http.routers.portainer.entrypoints=websecure"
+      - "traefik.http.services.portainer.loadbalancer.server.port=9000"
+    networks:
+      - production
 
 volumes:
   portainer_data:


### PR DESCRIPTION
Introduce README for Portainer with setup, usage steps, and Traefik integration details.